### PR TITLE
refactor: CustomizableBrowserToolbar, Observable canGoBack/Forward

### DIFF
--- a/ObservableWebView.xcodeproj/project.pbxproj
+++ b/ObservableWebView.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		29C1098E2BA4E89B00F88BBD /* SFSymbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C1098D2BA4E89B00F88BBD /* SFSymbol.swift */; };
 		29C109912BA4E8CB00F88BBD /* SymbolButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C109902BA4E8CB00F88BBD /* SymbolButtons.swift */; };
 		29CF6F5F2BA9FF9000C4E482 /* CustomizableBrowserToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CF6F5E2BA9FF9000C4E482 /* CustomizableBrowserToolbar.swift */; };
+		29CF6F622BAA13E800C4E482 /* UrlSearchBarTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CF6F612BAA13E800C4E482 /* UrlSearchBarTextField.swift */; };
+		29CF6F642BAA14C700C4E482 /* CustomizableToolbarIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CF6F632BAA14C700C4E482 /* CustomizableToolbarIdentifiers.swift */; };
+		29CF6F662BAA156800C4E482 /* WindowProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CF6F652BAA156800C4E482 /* WindowProperties.swift */; };
 		29EA6FDB2BA49F1300C8AB11 /* ObservableWebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA6FDA2BA49F1300C8AB11 /* ObservableWebViewManager.swift */; };
 		29EA6FDD2BA4A03500C8AB11 /* ObservableWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA6FDC2BA4A03500C8AB11 /* ObservableWebView.swift */; };
 /* End PBXBuildFile section */
@@ -35,6 +38,9 @@
 		29C1098D2BA4E89B00F88BBD /* SFSymbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSymbol.swift; sourceTree = "<group>"; };
 		29C109902BA4E8CB00F88BBD /* SymbolButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolButtons.swift; sourceTree = "<group>"; };
 		29CF6F5E2BA9FF9000C4E482 /* CustomizableBrowserToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizableBrowserToolbar.swift; sourceTree = "<group>"; };
+		29CF6F612BAA13E800C4E482 /* UrlSearchBarTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlSearchBarTextField.swift; sourceTree = "<group>"; };
+		29CF6F632BAA14C700C4E482 /* CustomizableToolbarIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizableToolbarIdentifiers.swift; sourceTree = "<group>"; };
+		29CF6F652BAA156800C4E482 /* WindowProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowProperties.swift; sourceTree = "<group>"; };
 		29EA6FDA2BA49F1300C8AB11 /* ObservableWebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableWebViewManager.swift; sourceTree = "<group>"; };
 		29EA6FDC2BA4A03500C8AB11 /* ObservableWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableWebView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -71,8 +77,9 @@
 			isa = PBXGroup;
 			children = (
 				29A079D82BA49C79006B9A80 /* ObservableWebViewApp.swift */,
+				29CF6F652BAA156800C4E482 /* WindowProperties.swift */,
 				29A079DA2BA49C79006B9A80 /* ContentView.swift */,
-				29CF6F5E2BA9FF9000C4E482 /* CustomizableBrowserToolbar.swift */,
+				29CF6F602BAA13BE00C4E482 /* Toolbar */,
 				29C109892BA4E4A600F88BBD /* Plugins */,
 				29C109832BA4C45500F88BBD /* Package */,
 				29A079DC2BA49C7A006B9A80 /* Assets.xcassets */,
@@ -133,6 +140,16 @@
 				29C1098A2BA4E4BA00F88BBD /* PlatformColor.swift */,
 			);
 			path = Colors;
+			sourceTree = "<group>";
+		};
+		29CF6F602BAA13BE00C4E482 /* Toolbar */ = {
+			isa = PBXGroup;
+			children = (
+				29CF6F632BAA14C700C4E482 /* CustomizableToolbarIdentifiers.swift */,
+				29CF6F5E2BA9FF9000C4E482 /* CustomizableBrowserToolbar.swift */,
+				29CF6F612BAA13E800C4E482 /* UrlSearchBarTextField.swift */,
+			);
+			path = Toolbar;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -205,15 +222,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				29CF6F642BAA14C700C4E482 /* CustomizableToolbarIdentifiers.swift in Sources */,
 				29C1098E2BA4E89B00F88BBD /* SFSymbol.swift in Sources */,
 				29C109852BA4C48600F88BBD /* ObservableWebViewLoadState.swift in Sources */,
 				29CF6F5F2BA9FF9000C4E482 /* CustomizableBrowserToolbar.swift in Sources */,
+				29CF6F662BAA156800C4E482 /* WindowProperties.swift in Sources */,
 				29EA6FDD2BA4A03500C8AB11 /* ObservableWebView.swift in Sources */,
 				29C109822BA4B0DD00F88BBD /* ObservableWebViewCoordinator.swift in Sources */,
 				29A079DB2BA49C79006B9A80 /* ContentView.swift in Sources */,
 				29EA6FDB2BA49F1300C8AB11 /* ObservableWebViewManager.swift in Sources */,
 				29C1098B2BA4E4BA00F88BBD /* PlatformColor.swift in Sources */,
 				29C109912BA4E8CB00F88BBD /* SymbolButtons.swift in Sources */,
+				29CF6F622BAA13E800C4E482 /* UrlSearchBarTextField.swift in Sources */,
 				29A079D92BA49C79006B9A80 /* ObservableWebViewApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ObservableWebView.xcodeproj/project.pbxproj
+++ b/ObservableWebView.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		29C1098B2BA4E4BA00F88BBD /* PlatformColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C1098A2BA4E4BA00F88BBD /* PlatformColor.swift */; };
 		29C1098E2BA4E89B00F88BBD /* SFSymbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C1098D2BA4E89B00F88BBD /* SFSymbol.swift */; };
 		29C109912BA4E8CB00F88BBD /* SymbolButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C109902BA4E8CB00F88BBD /* SymbolButtons.swift */; };
+		29CF6F5F2BA9FF9000C4E482 /* CustomizableBrowserToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CF6F5E2BA9FF9000C4E482 /* CustomizableBrowserToolbar.swift */; };
 		29EA6FDB2BA49F1300C8AB11 /* ObservableWebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA6FDA2BA49F1300C8AB11 /* ObservableWebViewManager.swift */; };
 		29EA6FDD2BA4A03500C8AB11 /* ObservableWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA6FDC2BA4A03500C8AB11 /* ObservableWebView.swift */; };
 /* End PBXBuildFile section */
@@ -33,6 +34,7 @@
 		29C1098A2BA4E4BA00F88BBD /* PlatformColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformColor.swift; sourceTree = "<group>"; };
 		29C1098D2BA4E89B00F88BBD /* SFSymbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSymbol.swift; sourceTree = "<group>"; };
 		29C109902BA4E8CB00F88BBD /* SymbolButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolButtons.swift; sourceTree = "<group>"; };
+		29CF6F5E2BA9FF9000C4E482 /* CustomizableBrowserToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizableBrowserToolbar.swift; sourceTree = "<group>"; };
 		29EA6FDA2BA49F1300C8AB11 /* ObservableWebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableWebViewManager.swift; sourceTree = "<group>"; };
 		29EA6FDC2BA4A03500C8AB11 /* ObservableWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableWebView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -70,6 +72,7 @@
 			children = (
 				29A079D82BA49C79006B9A80 /* ObservableWebViewApp.swift */,
 				29A079DA2BA49C79006B9A80 /* ContentView.swift */,
+				29CF6F5E2BA9FF9000C4E482 /* CustomizableBrowserToolbar.swift */,
 				29C109892BA4E4A600F88BBD /* Plugins */,
 				29C109832BA4C45500F88BBD /* Package */,
 				29A079DC2BA49C7A006B9A80 /* Assets.xcassets */,
@@ -204,6 +207,7 @@
 			files = (
 				29C1098E2BA4E89B00F88BBD /* SFSymbol.swift in Sources */,
 				29C109852BA4C48600F88BBD /* ObservableWebViewLoadState.swift in Sources */,
+				29CF6F5F2BA9FF9000C4E482 /* CustomizableBrowserToolbar.swift in Sources */,
 				29EA6FDD2BA4A03500C8AB11 /* ObservableWebView.swift in Sources */,
 				29C109822BA4B0DD00F88BBD /* ObservableWebViewCoordinator.swift in Sources */,
 				29A079DB2BA49C79006B9A80 /* ContentView.swift in Sources */,

--- a/ObservableWebView/ContentView.swift
+++ b/ObservableWebView/ContentView.swift
@@ -7,46 +7,56 @@
 
 import SwiftUI
 
+@Observable
+class WindowProperties {
+  var width: CGFloat = 0
+}
+
 struct ContentView: View {
   @State var webViewManager = ObservableWebViewManager()
+  @State private var windowProperties = WindowProperties()
   @State private var webContentThemeColor: Color = .clear
   
   var body: some View {
-    VStack {
-      
-      ObservableWebView(manager: webViewManager)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear {
-          webViewManager.webView.allowsBackForwardNavigationGestures = true
-          webViewManager.load("https://duckduckgo.com")
+    GeometryReader { geometry in
+      VStack {
+        ObservableWebView(manager: webViewManager)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .onAppear {
+            webViewManager.webView.allowsBackForwardNavigationGestures = true
+            webViewManager.load("https://duckduckgo.com")
+          }
+          .onChange(of: webViewManager.urlString) {
+            observedUrlChange()
+          }
+          .onChange(of: webViewManager.progress) {
+            observedProgressChange()
+          }
+          .onChange(of: webViewManager.loadState) { oldState, newState in
+            observedLoadStateChange(from: oldState, to: newState)
+          }
+        
+        HStack {
+          Spacer()
+          Button("Load Wikipedia") {
+            webViewManager.load("https://www.wikipedia.org")
+          }
+          Button("Load Apple") {
+            webViewManager.load("https://apple.com")
+          }
+          Button("Theme Site") {
+            webViewManager.load("https://scinfu.github.io/SwiftSoup/")
+          }
+          Spacer()
         }
-        .onChange(of: webViewManager.urlString) {
-          observedUrlChange()
-        }
-        .onChange(of: webViewManager.progress) {
-          observedProgressChange()
-        }
-        .onChange(of: webViewManager.loadState) { oldState, newState in
-          observedLoadStateChange(from: oldState, to: newState)
-        }
-      
-      HStack {
-        Spacer()
-        Button("Load Wikipedia") {
-          webViewManager.load("https://www.wikipedia.org")
-        }
-        Button("Load Apple") {
-          webViewManager.load("https://apple.com")
-        }
-        Button("Theme Site") {
-          webViewManager.load("https://scinfu.github.io/SwiftSoup/")
-        }
-        Spacer()
+        .padding(.bottom, 8)
       }
-      .padding(.bottom, 8)
+      .onChange(of: geometry.size.width) {
+        windowProperties.width = geometry.size.width
+      }
     }
     .toolbar(id: CustomizableToolbar.editingtools.id) {
-      CustomizableBrowserToolbar(manager: webViewManager)
+      CustomizableBrowserToolbar(manager: webViewManager, windowProperties: windowProperties)
     }
     .toolbarBackground(webContentThemeColor, for: .windowToolbar)
     .navigationTitle("")

--- a/ObservableWebView/ContentView.swift
+++ b/ObservableWebView/ContentView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct ContentView: View {
   @State var webViewManager = ObservableWebViewManager()
   @State private var webContentThemeColor: Color = .clear
-  @State private var toolbarStringText = ""
   
   var body: some View {
     VStack {
@@ -47,7 +46,7 @@ struct ContentView: View {
       .padding(.bottom, 8)
     }
     .toolbar(id: CustomizableToolbar.editingtools.id) {
-      CustomizableBrowserToolbar(manager: webViewManager, toolbarStringText: $toolbarStringText)
+      CustomizableBrowserToolbar(manager: webViewManager)
     }
     .toolbarBackground(webContentThemeColor, for: .windowToolbar)
     .navigationTitle("")

--- a/ObservableWebView/ContentView.swift
+++ b/ObservableWebView/ContentView.swift
@@ -7,26 +7,9 @@
 
 import SwiftUI
 
-@Observable
-class WindowProperties {
-  var width: CGFloat = 0
-}
-
-struct WindowPropertiesKey: EnvironmentKey {
-  static let defaultValue: WindowProperties = WindowProperties()
-}
-
-extension EnvironmentValues {
-  var windowProperties: WindowProperties {
-    get { self[WindowPropertiesKey.self] }
-    set { self[WindowPropertiesKey.self] = newValue }
-  }
-}
-
 struct ContentView: View {
   @State var webViewManager = ObservableWebViewManager()
   @State private var webContentThemeColor: Color = .clear
-  
   @Environment(\.windowProperties) private var windowProperties
   
   var body: some View {

--- a/ObservableWebView/ContentView.swift
+++ b/ObservableWebView/ContentView.swift
@@ -54,7 +54,8 @@ struct ContentView: View {
   }
   
   func observedUrlChange() {
-    print("webViewManager.urlString: \(webViewManager.urlString)")
+    guard let urlString = webViewManager.urlString else { return }
+    print("webViewManager.urlString: \(urlString)")
   }
   
   func observedProgressChange() {

--- a/ObservableWebView/ContentView.swift
+++ b/ObservableWebView/ContentView.swift
@@ -104,34 +104,3 @@ extension ContentView {
     }
   }
 }
-
-import SwiftUI
-
-struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
-  let manager: ObservableWebViewManager
-  @Binding var toolbarStringText: String
-  
-  var body: some CustomizableToolbarContent {
-    ToolbarItem(id: "backButton", placement: .automatic) {
-      ToolbarSymbolButton(title: "Back", symbol: .back, action: manager.goBack)
-        .disabled(!manager.canGoBack)
-    }
-    
-    ToolbarItem(id: "forwardButton", placement: .automatic) {
-      ToolbarSymbolButton(title: "Forward", symbol: .forward, action: manager.goForward)
-        .disabled(!manager.canGoForward)
-    }
-    
-    ToolbarItem(id: "urlSearchBar", placement: .automatic) {
-      TextField("Search or type URL", text: $toolbarStringText)
-        .textFieldStyle(RoundedBorderTextFieldStyle())
-        .frame(minWidth: 150, maxWidth: 300)
-        .onSubmit {
-          manager.load(toolbarStringText)
-        }
-        .onChange(of: manager.urlString) {
-          toolbarStringText = manager.urlString
-        }
-    }
-  }
-}

--- a/ObservableWebView/ContentView.swift
+++ b/ObservableWebView/ContentView.swift
@@ -46,7 +46,7 @@ struct ContentView: View {
       }
       .padding(.bottom, 8)
     }
-    .toolbar(id: "editingtools") {
+    .toolbar(id: CustomizableToolbar.editingtools.id) {
       CustomizableBrowserToolbar(manager: webViewManager, toolbarStringText: $toolbarStringText)
     }
     .toolbarBackground(webContentThemeColor, for: .windowToolbar)

--- a/ObservableWebView/ContentView.swift
+++ b/ObservableWebView/ContentView.swift
@@ -17,6 +17,10 @@ struct ContentView: View {
       
       ObservableWebView(manager: webViewManager)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear {
+          webViewManager.webView.allowsBackForwardNavigationGestures = true
+          webViewManager.load("https://duckduckgo.com")
+        }
         .onChange(of: webViewManager.urlString) {
           observedUrlChange()
         }

--- a/ObservableWebView/ContentView.swift
+++ b/ObservableWebView/ContentView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct ContentView: View {
   @State var webViewManager = ObservableWebViewManager()
-  
   @State private var webContentThemeColor: Color = .clear
+  @State private var toolbarStringText = ""
   
   var body: some View {
     VStack {
@@ -46,9 +46,8 @@ struct ContentView: View {
       }
       .padding(.bottom, 8)
     }
-    .toolbar {
-      NavigationToolbarContent(manager: webViewManager)
-      browserToolbar
+    .toolbar(id: "editingtools") {
+      CustomizableBrowserToolbar(manager: webViewManager, toolbarStringText: $toolbarStringText)
     }
     .toolbarBackground(webContentThemeColor, for: .windowToolbar)
     .navigationTitle("")
@@ -76,33 +75,6 @@ struct ContentView: View {
     default:
       break
     }
-  }
-  
-  @State private var toolbarStringText = ""
-  
-  private var browserToolbar: some ToolbarContent {
-    ToolbarItemGroup(placement: .navigation, content: {
-      /*
-      ToolbarSymbolButton(title: "Back", symbol: .back, action: {
-        webViewManager.goBack()
-      })
-      .disabled(webViewManager.canGoBack == false)
-      
-      ToolbarSymbolButton(title: "Forward", symbol: .forward, action: {
-        webViewManager.webView.goForward()
-      })
-      .disabled(webViewManager.webView.canGoForward == false)
-      */
-      TextField("Search or type URL", text: $toolbarStringText, onCommit: {
-        webViewManager.load(toolbarStringText)
-      })
-      .textFieldStyle(RoundedBorderTextFieldStyle())
-      .frame(minWidth: 150, maxWidth: 1000)
-      .onChange(of: webViewManager.urlString) {
-        toolbarStringText = webViewManager.urlString
-      }
-      
-    })
   }
 }
 
@@ -148,6 +120,41 @@ extension ContentView {
   func updateWebContentThemeColor(to color: Color) {
     withAnimation {
       webContentThemeColor = color
+    }
+  }
+}
+
+import SwiftUI
+
+struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
+  let manager: ObservableWebViewManager
+  @Binding var toolbarStringText: String
+  
+  var body: some CustomizableToolbarContent {
+    ToolbarItem(id: "backButton", placement: .automatic) {
+      Button(action: manager.goBack) {
+        Label("Back", systemImage: "arrow.left")
+      }
+      .disabled(!manager.canGoBack)
+    }
+    
+    ToolbarItem(id: "forwardButton", placement: .automatic) {
+      Button(action: manager.goForward) {
+        Label("Forward", systemImage: "arrow.right")
+      }
+      .disabled(!manager.canGoForward)
+    }
+    
+    ToolbarItem(id: "urlSearchBar", placement: .automatic) {
+      TextField("Search or type URL", text: $toolbarStringText)
+        .textFieldStyle(RoundedBorderTextFieldStyle())
+        .frame(minWidth: 150, maxWidth: 300)
+        .onSubmit {
+          manager.load(toolbarStringText)
+        }
+        .onChange(of: manager.urlString) {
+          toolbarStringText = manager.urlString
+        }
     }
   }
 }

--- a/ObservableWebView/ContentView.swift
+++ b/ObservableWebView/ContentView.swift
@@ -78,25 +78,6 @@ struct ContentView: View {
   }
 }
 
-import SwiftUI
-
-struct NavigationToolbarContent: ToolbarContent {
-  let manager: ObservableWebViewManager
-  
-  init(manager: ObservableWebViewManager) {
-    self.manager = manager
-  }
-  
-  var body: some ToolbarContent {
-    ToolbarItemGroup(placement: .automatic) {
-      ToolbarSymbolButton(title: "Back", symbol: .back, action: manager.goBack)
-        .disabled(!manager.canGoBack)
-      ToolbarSymbolButton(title: "Forward", symbol: .forward, action: manager.goForward)
-        .disabled(!manager.canGoForward)
-    }
-  }
-}
-
 #Preview {
   ContentView()
     .frame(width: 400, height: 600)
@@ -132,17 +113,13 @@ struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
   
   var body: some CustomizableToolbarContent {
     ToolbarItem(id: "backButton", placement: .automatic) {
-      Button(action: manager.goBack) {
-        Label("Back", systemImage: "arrow.left")
-      }
-      .disabled(!manager.canGoBack)
+      ToolbarSymbolButton(title: "Back", symbol: .back, action: manager.goBack)
+        .disabled(!manager.canGoBack)
     }
     
     ToolbarItem(id: "forwardButton", placement: .automatic) {
-      Button(action: manager.goForward) {
-        Label("Forward", systemImage: "arrow.right")
-      }
-      .disabled(!manager.canGoForward)
+      ToolbarSymbolButton(title: "Forward", symbol: .forward, action: manager.goForward)
+        .disabled(!manager.canGoForward)
     }
     
     ToolbarItem(id: "urlSearchBar", placement: .automatic) {

--- a/ObservableWebView/ContentView.swift
+++ b/ObservableWebView/ContentView.swift
@@ -43,10 +43,8 @@ struct ContentView: View {
       .padding(.bottom, 8)
     }
     .toolbar {
-      // Does work
-      NavigationToolbarContent(manager: webViewManager, canGoBack: webViewManager.canGoBack, canGoForward: webViewManager.canGoForward)
-      // Doesn't work
-      TestNavigationToolbarContent(manager: webViewManager)
+      NavigationToolbarContent(manager: webViewManager)
+      browserToolbar
     }
     .toolbarBackground(webContentThemeColor, for: .windowToolbar)
     .navigationTitle("")
@@ -80,6 +78,7 @@ struct ContentView: View {
   
   private var browserToolbar: some ToolbarContent {
     ToolbarItemGroup(placement: .navigation, content: {
+      /*
       ToolbarSymbolButton(title: "Back", symbol: .back, action: {
         webViewManager.goBack()
       })
@@ -89,7 +88,7 @@ struct ContentView: View {
         webViewManager.webView.goForward()
       })
       .disabled(webViewManager.webView.canGoForward == false)
-      
+      */
       TextField("Search or type URL", text: $toolbarStringText, onCommit: {
         webViewManager.load(toolbarStringText)
       })
@@ -107,45 +106,17 @@ import SwiftUI
 
 struct NavigationToolbarContent: ToolbarContent {
   let manager: ObservableWebViewManager
-  let canGoBack: Bool
-  let canGoForward: Bool
-  
-  var body: some ToolbarContent {
-    ToolbarItemGroup(placement: .automatic) {
-      ToolbarSymbolButton(title: "Back", symbol: .back, action: manager.goBack)
-        .disabled(canGoBack == false)
-      ToolbarSymbolButton(title: "Forward", symbol: .forward, action: manager.goForward)
-        .disabled(canGoForward == false)
-    }
-  }
-}
-
-struct TestNavigationToolbarContent: ToolbarContent {
-  let manager: ObservableWebViewManager
-  @State private var canGoBack = false
-  @State private var canGoForward = false
   
   init(manager: ObservableWebViewManager) {
     self.manager = manager
-    
-    observeBackState()
-  }
-  
-  func observeBackState() {
-    withObservationTracking {
-      print("canGoBack: \(manager.webView.canGoBack)")
-      canGoBack = manager.webView.canGoBack
-    } onChange: {
-      Task { observeBackState() }
-    }
   }
   
   var body: some ToolbarContent {
     ToolbarItemGroup(placement: .automatic) {
       ToolbarSymbolButton(title: "Back", symbol: .back, action: manager.goBack)
-        .disabled(manager.webView.canGoBack == false)
+        .disabled(!manager.canGoBack)
       ToolbarSymbolButton(title: "Forward", symbol: .forward, action: manager.goForward)
-        .disabled(canGoForward == false)
+        .disabled(!manager.canGoForward)
     }
   }
 }

--- a/ObservableWebView/ContentView.swift
+++ b/ObservableWebView/ContentView.swift
@@ -12,11 +12,22 @@ class WindowProperties {
   var width: CGFloat = 0
 }
 
+struct WindowPropertiesKey: EnvironmentKey {
+  static let defaultValue: WindowProperties = WindowProperties()
+}
+
+extension EnvironmentValues {
+  var windowProperties: WindowProperties {
+    get { self[WindowPropertiesKey.self] }
+    set { self[WindowPropertiesKey.self] = newValue }
+  }
+}
+
 struct ContentView: View {
   @State var webViewManager = ObservableWebViewManager()
   @State private var webContentThemeColor: Color = .clear
   
-  @Environment(WindowProperties.self) private var windowProperties
+  @Environment(\.windowProperties) private var windowProperties
   
   var body: some View {
     GeometryReader { geometry in

--- a/ObservableWebView/ContentView.swift
+++ b/ObservableWebView/ContentView.swift
@@ -45,16 +45,16 @@ struct ContentView: View {
           Spacer()
         }
         .padding(.bottom, 8)
+        
       }
       .onChange(of: geometry.size.width) {
         windowProperties.width = geometry.size.width
       }
     }
-    .toolbar(id: CustomizableToolbar.editingtools.id) {
+    .toolbar(id: ToolbarIdentifier.editingtools.id) {
       CustomizableBrowserToolbar(manager: webViewManager)
     }
     .toolbarBackground(webContentThemeColor, for: .windowToolbar)
-    .navigationTitle("")
   }
   
   func observedUrlChange() {

--- a/ObservableWebView/ContentView.swift
+++ b/ObservableWebView/ContentView.swift
@@ -14,8 +14,9 @@ class WindowProperties {
 
 struct ContentView: View {
   @State var webViewManager = ObservableWebViewManager()
-  @State private var windowProperties = WindowProperties()
   @State private var webContentThemeColor: Color = .clear
+  
+  @Environment(WindowProperties.self) private var windowProperties
   
   var body: some View {
     GeometryReader { geometry in
@@ -56,7 +57,7 @@ struct ContentView: View {
       }
     }
     .toolbar(id: CustomizableToolbar.editingtools.id) {
-      CustomizableBrowserToolbar(manager: webViewManager, windowProperties: windowProperties)
+      CustomizableBrowserToolbar(manager: webViewManager)
     }
     .toolbarBackground(webContentThemeColor, for: .windowToolbar)
     .navigationTitle("")

--- a/ObservableWebView/CustomizableBrowserToolbar.swift
+++ b/ObservableWebView/CustomizableBrowserToolbar.swift
@@ -25,9 +25,13 @@ enum CustomizableToolbarItem: String {
 
 struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
   let manager: ObservableWebViewManager
-  @Binding var toolbarStringText: String
   
   var body: some CustomizableToolbarContent {
+    ToolbarItem(id: CustomizableToolbarItem.urlSearchBar.id, placement: .automatic) {
+      UrlSearchBarTextField(manager: manager)
+    }
+    .customizationBehavior(.reorderable)
+    
     ToolbarItem(id: CustomizableToolbarItem.backButton.id, placement: .automatic) {
       ToolbarSymbolButton(title: "Back", symbol: .back, action: manager.goBack)
         .disabled(!manager.canGoBack)
@@ -37,20 +41,28 @@ struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
       ToolbarSymbolButton(title: "Forward", symbol: .forward, action: manager.goForward)
         .disabled(!manager.canGoForward)
     }
-    
-    ToolbarItem(id: CustomizableToolbarItem.urlSearchBar.id, placement: .automatic) {
-      TextField("Search or type URL", text: $toolbarStringText)
-        .textFieldStyle(RoundedBorderTextFieldStyle())
-        .frame(minWidth: 150, maxWidth: 300)
-        .onSubmit {
-          manager.load(toolbarStringText)
-        }
-        .onChange(of: manager.urlString) {
-          if let urlString = manager.urlString {
-            toolbarStringText = urlString
-          }
-        }
-    }
+  }
+}
+
+struct UrlSearchBarTextField: View {
+  let manager: ObservableWebViewManager
+  @State private var text: String = ""
+  
+  var body: some View {
+    TextField("Search or type URL", text: $text)
+      .textFieldStyle(RoundedBorderTextFieldStyle())
+      .frame(minWidth: 150, maxWidth: 300)
+      .onSubmit {
+        manager.load(text)
+      }
+      .onChange(of: manager.urlString) {
+        observedUrlChange()
+      }
+  }
+  
+  func observedUrlChange() {
+    guard let urlString = manager.urlString else { return }
+    text = urlString
   }
 }
 

--- a/ObservableWebView/CustomizableBrowserToolbar.swift
+++ b/ObservableWebView/CustomizableBrowserToolbar.swift
@@ -7,6 +7,14 @@
 
 import SwiftUI
 
+enum CustomizableToolbar: String {
+  case editingtools
+  
+  var id: String {
+    self.rawValue
+  }
+}
+
 enum CustomizableToolbarItem: String {
   case backButton, forwardButton, urlSearchBar
   

--- a/ObservableWebView/CustomizableBrowserToolbar.swift
+++ b/ObservableWebView/CustomizableBrowserToolbar.swift
@@ -7,22 +7,30 @@
 
 import SwiftUI
 
+enum CustomizableToolbarItem: String {
+  case backButton, forwardButton, urlSearchBar
+  
+  var id: String {
+    self.rawValue
+  }
+}
+
 struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
   let manager: ObservableWebViewManager
   @Binding var toolbarStringText: String
   
   var body: some CustomizableToolbarContent {
-    ToolbarItem(id: "backButton", placement: .automatic) {
+    ToolbarItem(id: CustomizableToolbarItem.backButton.id, placement: .automatic) {
       ToolbarSymbolButton(title: "Back", symbol: .back, action: manager.goBack)
         .disabled(!manager.canGoBack)
     }
     
-    ToolbarItem(id: "forwardButton", placement: .automatic) {
+    ToolbarItem(id: CustomizableToolbarItem.forwardButton.id, placement: .automatic) {
       ToolbarSymbolButton(title: "Forward", symbol: .forward, action: manager.goForward)
         .disabled(!manager.canGoForward)
     }
     
-    ToolbarItem(id: "urlSearchBar", placement: .automatic) {
+    ToolbarItem(id: CustomizableToolbarItem.urlSearchBar.id, placement: .automatic) {
       TextField("Search or type URL", text: $toolbarStringText)
         .textFieldStyle(RoundedBorderTextFieldStyle())
         .frame(minWidth: 150, maxWidth: 300)

--- a/ObservableWebView/CustomizableBrowserToolbar.swift
+++ b/ObservableWebView/CustomizableBrowserToolbar.swift
@@ -25,7 +25,7 @@ enum CustomizableToolbarItem: String {
 
 struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
   let manager: ObservableWebViewManager
-  @Environment(WindowProperties.self) private var windowProperties
+  @Environment(\.windowProperties) private var windowProperties
   
   var body: some CustomizableToolbarContent {
     ToolbarItem(id: CustomizableToolbarItem.urlSearchBar.id, placement: .automatic) {

--- a/ObservableWebView/CustomizableBrowserToolbar.swift
+++ b/ObservableWebView/CustomizableBrowserToolbar.swift
@@ -25,7 +25,7 @@ enum CustomizableToolbarItem: String {
 
 struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
   let manager: ObservableWebViewManager
-  let windowProperties: WindowProperties
+  @Environment(WindowProperties.self) private var windowProperties
   
   var body: some CustomizableToolbarContent {
     ToolbarItem(id: CustomizableToolbarItem.urlSearchBar.id, placement: .automatic) {

--- a/ObservableWebView/CustomizableBrowserToolbar.swift
+++ b/ObservableWebView/CustomizableBrowserToolbar.swift
@@ -1,0 +1,43 @@
+//
+//  CustomizableBrowserToolbar.swift
+//  ObservableWebView
+//
+//  Created by Justin Bush on 3/19/24.
+//
+
+import SwiftUI
+
+struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
+  let manager: ObservableWebViewManager
+  @Binding var toolbarStringText: String
+  
+  var body: some CustomizableToolbarContent {
+    ToolbarItem(id: "backButton", placement: .automatic) {
+      ToolbarSymbolButton(title: "Back", symbol: .back, action: manager.goBack)
+        .disabled(!manager.canGoBack)
+    }
+    
+    ToolbarItem(id: "forwardButton", placement: .automatic) {
+      ToolbarSymbolButton(title: "Forward", symbol: .forward, action: manager.goForward)
+        .disabled(!manager.canGoForward)
+    }
+    
+    ToolbarItem(id: "urlSearchBar", placement: .automatic) {
+      TextField("Search or type URL", text: $toolbarStringText)
+        .textFieldStyle(RoundedBorderTextFieldStyle())
+        .frame(minWidth: 150, maxWidth: 300)
+        .onSubmit {
+          manager.load(toolbarStringText)
+        }
+        .onChange(of: manager.urlString) {
+          toolbarStringText = manager.urlString
+        }
+    }
+  }
+}
+
+
+#Preview {
+  ContentView()
+    .frame(width: 400, height: 600)
+}

--- a/ObservableWebView/CustomizableBrowserToolbar.swift
+++ b/ObservableWebView/CustomizableBrowserToolbar.swift
@@ -25,10 +25,12 @@ enum CustomizableToolbarItem: String {
 
 struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
   let manager: ObservableWebViewManager
+  let windowProperties: WindowProperties
   
   var body: some CustomizableToolbarContent {
     ToolbarItem(id: CustomizableToolbarItem.urlSearchBar.id, placement: .automatic) {
       UrlSearchBarTextField(manager: manager)
+        .frame(minWidth: calculateTextFieldWidth(for: windowProperties.width), maxWidth: 800)
     }
     .customizationBehavior(.reorderable)
     
@@ -44,6 +46,16 @@ struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
   }
 }
 
+extension CustomizableBrowserToolbar {
+  fileprivate func calculateTextFieldWidth(for availableWidth: CGFloat) -> CGFloat {
+    let minWidth: CGFloat = 240
+    let maxWidth: CGFloat = 800
+    let adaptiveWidth = availableWidth * 0.4
+    
+    return min(maxWidth, max(minWidth, adaptiveWidth))
+  }
+}
+
 struct UrlSearchBarTextField: View {
   let manager: ObservableWebViewManager
   @State private var text: String = ""
@@ -51,7 +63,6 @@ struct UrlSearchBarTextField: View {
   var body: some View {
     TextField("Search or type URL", text: $text)
       .textFieldStyle(RoundedBorderTextFieldStyle())
-      .frame(minWidth: 150, maxWidth: 300)
       .onSubmit {
         manager.load(text)
       }

--- a/ObservableWebView/CustomizableBrowserToolbar.swift
+++ b/ObservableWebView/CustomizableBrowserToolbar.swift
@@ -38,7 +38,9 @@ struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
           manager.load(toolbarStringText)
         }
         .onChange(of: manager.urlString) {
-          toolbarStringText = manager.urlString
+          if let urlString = manager.urlString {
+            toolbarStringText = urlString
+          }
         }
     }
   }

--- a/ObservableWebView/ObservableWebViewApp.swift
+++ b/ObservableWebView/ObservableWebViewApp.swift
@@ -13,5 +13,8 @@ struct ObservableWebViewApp: App {
     WindowGroup {
       ContentView()
     }
+    .commands {
+      ToolbarCommands()
+    }
   }
 }

--- a/ObservableWebView/ObservableWebViewApp.swift
+++ b/ObservableWebView/ObservableWebViewApp.swift
@@ -14,6 +14,7 @@ struct ObservableWebViewApp: App {
       ContentView()
         .environment(WindowProperties())
     }
+    .windowToolbarStyle(.unified(showsTitle: false))
     .commands {
       ToolbarCommands()
     }

--- a/ObservableWebView/ObservableWebViewApp.swift
+++ b/ObservableWebView/ObservableWebViewApp.swift
@@ -12,6 +12,7 @@ struct ObservableWebViewApp: App {
   var body: some Scene {
     WindowGroup {
       ContentView()
+        .environment(WindowProperties())
     }
     .commands {
       ToolbarCommands()

--- a/ObservableWebView/Package/ObservableWebViewCoordinator.swift
+++ b/ObservableWebView/Package/ObservableWebViewCoordinator.swift
@@ -10,11 +10,14 @@ import WebKit
 class ObservableWebViewCoordinator: NSObject, WKNavigationDelegate {
   var observableWebView: ObservableWebView
   private var progressObservation: NSKeyValueObservation?
+  private var canGoBackObservation: NSKeyValueObservation?
+  private var canGoForwardObservation: NSKeyValueObservation?
   
   init(_ webView: ObservableWebView) {
     self.observableWebView = webView
     super.init()
     setupProgressObservation()
+    setupCanGoBackAndForwardObservation()
   }
   
   func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
@@ -45,8 +48,20 @@ class ObservableWebViewCoordinator: NSObject, WKNavigationDelegate {
     }
   }
   
+  private func setupCanGoBackAndForwardObservation() {
+    canGoBackObservation = observableWebView.manager.webView.observe(\.canGoBack, options: .new) { [weak self] webView, _ in
+      self?.observableWebView.manager.canGoBack = webView.canGoBack
+    }
+    
+    canGoForwardObservation = observableWebView.manager.webView.observe(\.canGoForward, options: .new) { [weak self] webView, _ in
+      self?.observableWebView.manager.canGoForward = webView.canGoForward
+    }
+  }
+  
   deinit {
     progressObservation?.invalidate()
+    canGoBackObservation?.invalidate()
+    canGoForwardObservation?.invalidate()
   }
 }
 

--- a/ObservableWebView/Package/ObservableWebViewManager.swift
+++ b/ObservableWebView/Package/ObservableWebViewManager.swift
@@ -24,13 +24,8 @@ class ObservableWebViewManager {
   var progress: Double = 0
   var urlString: String = ""
   
-  var canGoBack: Bool {
-    webView.canGoBack
-  }
-  
-  var canGoForward: Bool {
-    webView.canGoForward
-  }
+  var canGoBack: Bool = false
+  var canGoForward: Bool = false
   
   func goBack() {
     webView.goBack()

--- a/ObservableWebView/Package/ObservableWebViewManager.swift
+++ b/ObservableWebView/Package/ObservableWebViewManager.swift
@@ -22,7 +22,7 @@ class ObservableWebViewManager {
   /// The current state of the WKWebView object.
   var loadState: ObservableWebViewLoadState = .idle
   var progress: Double = 0
-  var urlString: String = ""
+  var urlString: String?
   
   var canGoBack: Bool = false
   var canGoForward: Bool = false
@@ -35,15 +35,17 @@ class ObservableWebViewManager {
     webView.goForward()
   }
   
-  init(urlString: String = Constants.aboutBlank) {
+  init(urlString: String? = nil) {
     self.webView = WKWebView()
     self.urlString = urlString
-    load(urlString)
+    if let urlString = urlString, !urlString.isEmpty {
+      load(urlString)
+    }
   }
   
   func load(_ urlString: String) {
     updateUrlString(withString: urlString)
-    let url = URL(string: urlString) ?? Constants.aboutBlankUrl
+    guard let url = URL(string: urlString) else { return }
     let request = URLRequest(url: url)
     webView.load(request)
   }

--- a/ObservableWebView/Package/ObservableWebViewManager.swift
+++ b/ObservableWebView/Package/ObservableWebViewManager.swift
@@ -9,13 +9,6 @@ import SwiftUI
 import WebKit
 import Observation
 
-extension ObservableWebViewManager {
-  private struct Constants {
-    static let aboutBlank = "about:blank"
-    static let aboutBlankUrl = URL(string: Constants.aboutBlank)!
-  }
-}
-
 @Observable
 class ObservableWebViewManager {
   var webView: WKWebView = WKWebView()

--- a/ObservableWebView/Toolbar/CustomizableBrowserToolbar.swift
+++ b/ObservableWebView/Toolbar/CustomizableBrowserToolbar.swift
@@ -7,20 +7,8 @@
 
 import SwiftUI
 
-enum CustomizableToolbar: String {
-  case editingtools
-  
-  var id: String {
-    self.rawValue
-  }
-}
-
 enum CustomizableToolbarItem: String {
   case backButton, forwardButton, urlSearchBar
-  
-  var id: String {
-    self.rawValue
-  }
 }
 
 struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
@@ -30,7 +18,7 @@ struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
   var body: some CustomizableToolbarContent {
     ToolbarItem(id: CustomizableToolbarItem.urlSearchBar.id, placement: .automatic) {
       UrlSearchBarTextField(manager: manager)
-        .frame(minWidth: calculateTextFieldWidth(for: windowProperties.width), maxWidth: 800)
+        .frame(width: calculateUrlSearchBarWidth(for: windowProperties.width))
     }
     .customizationBehavior(.reorderable)
     
@@ -46,39 +34,19 @@ struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
   }
 }
 
+
+#Preview {
+  ContentView()
+    .frame(width: 400, height: 600)
+}
+
+
 extension CustomizableBrowserToolbar {
-  fileprivate func calculateTextFieldWidth(for availableWidth: CGFloat) -> CGFloat {
+  fileprivate func calculateUrlSearchBarWidth(for availableWidth: CGFloat) -> CGFloat {
     let minWidth: CGFloat = 240
     let maxWidth: CGFloat = 800
     let adaptiveWidth = availableWidth * 0.4
     
     return min(maxWidth, max(minWidth, adaptiveWidth))
   }
-}
-
-struct UrlSearchBarTextField: View {
-  let manager: ObservableWebViewManager
-  @State private var text: String = ""
-  
-  var body: some View {
-    TextField("Search or type URL", text: $text)
-      .textFieldStyle(RoundedBorderTextFieldStyle())
-      .onSubmit {
-        manager.load(text)
-      }
-      .onChange(of: manager.urlString) {
-        observedUrlChange()
-      }
-  }
-  
-  func observedUrlChange() {
-    guard let urlString = manager.urlString else { return }
-    text = urlString
-  }
-}
-
-
-#Preview {
-  ContentView()
-    .frame(width: 400, height: 600)
 }

--- a/ObservableWebView/Toolbar/CustomizableBrowserToolbar.swift
+++ b/ObservableWebView/Toolbar/CustomizableBrowserToolbar.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-enum CustomizableToolbarItem: String {
+enum ToolbarItemIdentifier: String {
   case backButton, forwardButton, urlSearchBar
 }
 
@@ -16,20 +16,38 @@ struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
   @Environment(\.windowProperties) private var windowProperties
   
   var body: some CustomizableToolbarContent {
-    ToolbarItem(id: CustomizableToolbarItem.urlSearchBar.id, placement: .automatic) {
+    spacer
+    backButton
+    urlSearchBarTextField
+    forwardButton
+    spacer
+  }
+  
+  var urlSearchBarTextField: some CustomizableToolbarContent {
+    ToolbarItem(id: ToolbarItemIdentifier.urlSearchBar.id, placement: .automatic) {
       UrlSearchBarTextField(manager: manager)
         .frame(width: calculateUrlSearchBarWidth(for: windowProperties.width))
     }
     .customizationBehavior(.reorderable)
-    
-    ToolbarItem(id: CustomizableToolbarItem.backButton.id, placement: .automatic) {
+  }
+  
+  var backButton: some CustomizableToolbarContent {
+    ToolbarItem(id: ToolbarItemIdentifier.backButton.id, placement: .automatic) {
       ToolbarSymbolButton(title: "Back", symbol: .back, action: manager.goBack)
         .disabled(!manager.canGoBack)
     }
-    
-    ToolbarItem(id: CustomizableToolbarItem.forwardButton.id, placement: .automatic) {
+  }
+  
+  var forwardButton: some CustomizableToolbarContent {
+    ToolbarItem(id: ToolbarItemIdentifier.forwardButton.id, placement: .automatic) {
       ToolbarSymbolButton(title: "Forward", symbol: .forward, action: manager.goForward)
         .disabled(!manager.canGoForward)
+    }
+  }
+  
+  var spacer: some CustomizableToolbarContent {
+    ToolbarItem(id: "spacer", placement: .automatic) {
+      Spacer()
     }
   }
 }

--- a/ObservableWebView/Toolbar/CustomizableToolbarIdentifiers.swift
+++ b/ObservableWebView/Toolbar/CustomizableToolbarIdentifiers.swift
@@ -1,0 +1,22 @@
+//
+//  CustomizableToolbarIdentifiers.swift
+//  ObservableWebView
+//
+//  Created by Justin Bush on 3/19/24.
+//
+
+import Foundation
+
+enum CustomizableToolbar: String {
+  case editingtools
+  
+  var id: String {
+    self.rawValue
+  }
+}
+
+extension CustomizableToolbarItem {
+  var id: String {
+    self.rawValue
+  }
+}

--- a/ObservableWebView/Toolbar/CustomizableToolbarIdentifiers.swift
+++ b/ObservableWebView/Toolbar/CustomizableToolbarIdentifiers.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum CustomizableToolbar: String {
+enum ToolbarIdentifier: String {
   case editingtools
   
   var id: String {
@@ -15,7 +15,7 @@ enum CustomizableToolbar: String {
   }
 }
 
-extension CustomizableToolbarItem {
+extension ToolbarItemIdentifier {
   var id: String {
     self.rawValue
   }

--- a/ObservableWebView/Toolbar/UrlSearchBarTextField.swift
+++ b/ObservableWebView/Toolbar/UrlSearchBarTextField.swift
@@ -14,6 +14,8 @@ struct UrlSearchBarTextField: View {
   var body: some View {
     TextField("Search or type URL", text: $text)
       .textFieldStyle(RoundedBorderTextFieldStyle())
+      .foregroundStyle(.primary)
+      .font(.system(size: 14, weight: .regular, design: .rounded))
       .onSubmit {
         manager.load(text)
       }

--- a/ObservableWebView/Toolbar/UrlSearchBarTextField.swift
+++ b/ObservableWebView/Toolbar/UrlSearchBarTextField.swift
@@ -1,0 +1,35 @@
+//
+//  UrlSearchBarTextField.swift
+//  ObservableWebView
+//
+//  Created by Justin Bush on 3/19/24.
+//
+
+import SwiftUI
+
+struct UrlSearchBarTextField: View {
+  let manager: ObservableWebViewManager
+  @State private var text: String = ""
+  
+  var body: some View {
+    TextField("Search or type URL", text: $text)
+      .textFieldStyle(RoundedBorderTextFieldStyle())
+      .onSubmit {
+        manager.load(text)
+      }
+      .onChange(of: manager.urlString) {
+        observedUrlChange()
+      }
+  }
+  
+  func observedUrlChange() {
+    guard let urlString = manager.urlString else { return }
+    text = urlString
+  }
+}
+
+
+#Preview {
+  ContentView()
+    .frame(width: 400, height: 600)
+}

--- a/ObservableWebView/WindowProperties.swift
+++ b/ObservableWebView/WindowProperties.swift
@@ -1,0 +1,24 @@
+//
+//  WindowProperties.swift
+//  ObservableWebView
+//
+//  Created by Justin Bush on 3/19/24.
+//
+
+import SwiftUI
+
+@Observable
+class WindowProperties {
+  var width: CGFloat = 0
+}
+
+struct WindowPropertiesKey: EnvironmentKey {
+  static let defaultValue: WindowProperties = WindowProperties()
+}
+
+extension EnvironmentValues {
+  var windowProperties: WindowProperties {
+    get { self[WindowPropertiesKey.self] }
+    set { self[WindowPropertiesKey.self] = newValue }
+  }
+}


### PR DESCRIPTION
<img width="864" alt="Screenshot 2024-03-19 at 11 23 40 AM" src="https://github.com/buzsh/ObservableWebView/assets/158503966/aeca9289-8151-40d1-9469-802396ca290b">

```swift
struct CustomizableBrowserToolbar: ToolbarContent, CustomizableToolbarContent {
  let manager: ObservableWebViewManager
  @Binding var toolbarStringText: String
  
  var body: some CustomizableToolbarContent {
    ToolbarItem(id: CustomizableToolbarItem.backButton.id, placement: .automatic) {
      ToolbarSymbolButton(title: "Back", symbol: .back, action: manager.goBack)
        .disabled(!manager.canGoBack)
    }
    
    ToolbarItem(id: CustomizableToolbarItem.forwardButton.id, placement: .automatic) {
      ToolbarSymbolButton(title: "Forward", symbol: .forward, action: manager.goForward)
        .disabled(!manager.canGoForward)
    }
    
    ToolbarItem(id: CustomizableToolbarItem.urlSearchBar.id, placement: .automatic) {
      TextField("Search or type URL", text: $toolbarStringText)
        .textFieldStyle(RoundedBorderTextFieldStyle())
        .frame(minWidth: 150, maxWidth: 300)
        .onSubmit {
          manager.load(toolbarStringText)
        }
        .onChange(of: manager.urlString) {
          toolbarStringText = manager.urlString
        }
    }
  }
}
```